### PR TITLE
argpcp: reduce re-allocations of intermediate matrices

### DIFF
--- a/changepoint/Cargo.toml
+++ b/changepoint/Cargo.toml
@@ -49,3 +49,11 @@ harness = false
 [[bench]]
 name = "bocpd_truncated"
 harness = false
+
+[[bench]]
+name = "argpcpd"
+harness = false
+
+[profile.profiling]
+inherits = "release"
+debug = 2

--- a/changepoint/benches/argpcpd.rs
+++ b/changepoint/benches/argpcpd.rs
@@ -1,0 +1,43 @@
+use changepoint::*;
+use criterion::*;
+use rv::process::gaussian::kernel::{ConstantKernel, RBFKernel, WhiteKernel};
+
+fn bench_argpcpd(c: &mut Criterion) {
+    let raw_data: &str = include_str!("../../resources/TB3MS.csv");
+    let data: Vec<f64> = raw_data
+        .lines()
+        .skip(1)
+        .map(|line| line.split_at(11).1.parse().unwrap())
+        .collect();
+
+    let mut group = c.benchmark_group("Argpcp");
+
+    for nelems in (0..500).step_by(100) {
+        let subdata: Vec<f64> = data.iter().take(nelems).copied().collect();
+
+        group.throughput(Throughput::Elements(nelems as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(nelems),
+            &subdata,
+            |b, data| {
+                b.iter(|| {
+                    let constant_kernel = ConstantKernel::new(0.5).unwrap();
+                    let rbf_kernel = RBFKernel::new(10.0).unwrap();
+                    let white_kernel = WhiteKernel::new(0.01).unwrap();
+                    let kernel = constant_kernel * rbf_kernel + white_kernel;
+                    // Create the Argpcp processor
+                    let mut cpd =
+                        Argpcp::new(kernel, 3, 2.0, 1.0, -5.0, 1.0, 1.0);
+
+                    // Feed data into change point detector
+                    let _res: Vec<Vec<f64>> =
+                        data.iter().map(|d| cpd.step(d).to_vec()).collect();
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_argpcpd);
+criterion_main!(benches);

--- a/changepoint/src/gp/mod.rs
+++ b/changepoint/src/gp/mod.rs
@@ -385,11 +385,11 @@ where
         self.mrc = self.run_length_pr.len();
 
         // Adjust other variables
-        self.u = self.u.view((0, 0), (self.mrc - 1, self.mrc - 1)).into();
+        self.u.resize_mut(self.mrc - 1, self.mrc - 1, 0.0);
         self.last_nlml = self.last_nlml.rows_range(0..(self.mrc - 1)).into();
-        self.alpha = self.alpha.view((0, 0), (self.mrc - 1, 1)).into();
-        self.alpha_t = self.alpha_t.view((0, 0), (self.mrc - 1, 1)).into();
-        self.beta_t = self.beta_t.view((0, 0), (self.mrc - 1, 1)).into();
+        self.alpha.resize_mut(self.mrc - 1, 1, 0.0);
+        self.alpha_t.resize_mut(self.mrc - 1, 1, 0.0);
+        self.beta_t.resize_mut(self.mrc - 1, 1, 0.0);
 
         &self.run_length_pr
     }


### PR DESCRIPTION
This PR adds a benchmark for the Argpcp detector and makes a small change to the adjustment of some matrices in `Argpcp::step` which in my benchmarks increases performance significantly due to the avoidance of some allocations:

```
cargo bench -- Argpcp
   Compiling changepoint v0.14.1 (/home/ben/repos/rust/changepoint/changepoint)
    Finished `bench` profile [optimized] target(s) in 1.00s
     Running benches/argpcpd.rs (target/release/deps/argpcpd-88c49aae90ec9b95)
Gnuplot not found, using plotters backend
Argpcp/0                time:   [29.239 ns 29.467 ns 29.877 ns]
                        thrpt:  [0.0000  elem/s 0.0000  elem/s 0.0000  elem/s]
                 change:
                        time:   [+1.2657% +1.7227% +2.3479%] (p = 0.00 < 0.05)
                        thrpt:  [-2.2941% -1.6935% -1.2499%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Argpcp/100              time:   [557.38 µs 559.40 µs 561.62 µs]
                        thrpt:  [178.06 Kelem/s 178.76 Kelem/s 179.41 Kelem/s]
                 change:
                        time:   [-19.031% -18.689% -18.396%] (p = 0.00 < 0.05)
                        thrpt:  [+22.542% +22.985% +23.504%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking Argpcp/200: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, enable flat sampling, or reduce sample count to 60.
Argpcp/200              time:   [1.1714 ms 1.1758 ms 1.1846 ms]
                        thrpt:  [168.84 Kelem/s 170.09 Kelem/s 170.74 Kelem/s]
                 change:
                        time:   [-17.492% -17.214% -16.867%] (p = 0.00 < 0.05)
                        thrpt:  [+20.288% +20.794% +21.200%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Argpcp/300              time:   [2.6930 ms 2.6975 ms 2.7022 ms]
                        thrpt:  [111.02 Kelem/s 111.21 Kelem/s 111.40 Kelem/s]
                 change:
                        time:   [-29.852% -29.230% -28.777%] (p = 0.00 < 0.05)
                        thrpt:  [+40.403% +41.304% +42.555%]
                        Performance has improved.
Argpcp/400              time:   [6.8981 ms 6.9056 ms 6.9134 ms]
                        thrpt:  [57.858 Kelem/s 57.924 Kelem/s 57.987 Kelem/s]
                 change:
                        time:   [-36.372% -36.289% -36.212%] (p = 0.00 < 0.05)
                        thrpt:  [+56.770% +56.958% +57.164%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

I got hold of some profiles by running `samply record -- cargo bench --profile profiling -- --profile-time 10 'Argpcp/400'`, in case you're interested:

- [old](https://share.firefox.dev/4bVYMhG)
- [new](https://share.firefox.dev/3X2gHPv)

And a quick [playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9b24c6aabf10a09a532e16ca2bed2d61) to make sure this does the right thing!