### PR TITLE
fix: use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -87,7 +87,7 @@ jobs:
           args: --release --out dist --find-interpreter --manifest-path pychangepoint/Cargo.toml
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -111,7 +111,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --manifest-path pychangepoint/Cargo.toml
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -134,7 +134,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --manifest-path pychangepoint/Cargo.toml
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist


### PR DESCRIPTION
actions/upload-artifact@v3 is deprecated as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/