### PR TITLE
chore: bump rv dependency to 0.18

### DIFF
--- a/changepoint/Cargo.toml
+++ b/changepoint/Cargo.toml
@@ -25,7 +25,7 @@ serde1 = ["serde", "rv/serde1"]
 
 [dependencies]
 rand = { version = "0.8", features = ["small_rng"] }
-rv = { version = "0.16", features = ["process", "arraydist"] }
+rv = { version = "0.18", features = ["process", "arraydist"] }
 nalgebra = { version = "0.32" }
 serde = {version = "1", optional = true, features=["derive"]}
 serde_derive = {version = "1", optional = true}

--- a/changepoint/src/bocpd.rs
+++ b/changepoint/src/bocpd.rs
@@ -45,7 +45,7 @@ where
 impl<X, Fx, Pr> Bocpd<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + Clone,
+    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + HasDensity<Fx> + Clone,
     Fx::Stat: Clone,
 {
     /// Create a new Bocpd analyzer
@@ -116,7 +116,7 @@ where
 impl<X, Fx, Pr> BocpdLike<X> for Bocpd<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + Clone,
+    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + HasDensity<Fx> + Clone,
     Fx::Stat: Clone,
 {
     type Fx = Fx;

--- a/changepoint/src/bocpd_truncated.rs
+++ b/changepoint/src/bocpd_truncated.rs
@@ -48,7 +48,7 @@ where
 impl<X, Fx, Pr> BocpdTruncated<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + Clone,
+    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + HasDensity<Fx> + Clone,
     Fx::Stat: Clone,
 {
     /// Create a new Bocpd analyzer
@@ -103,7 +103,7 @@ where
 impl<X, Fx, Pr> BocpdTruncated<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + Clone,
+    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + HasDensity<Fx> + Clone,
     Fx::Stat: Clone,
 {
     /// Reduce the observed values into a new BOCPD with those observed values integrated into the
@@ -130,7 +130,7 @@ where
 impl<X, Fx, Pr> BocpdLike<X> for BocpdTruncated<X, Fx, Pr>
 where
     Fx: Rv<X> + HasSuffStat<X>,
-    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + Clone,
+    Pr: ConjugatePrior<X, Fx, Posterior = Pr> + HasDensity<Fx> + Clone,
     Fx::Stat: Clone,
 {
     type Fx = Fx;

--- a/changepoint/src/generators.rs
+++ b/changepoint/src/generators.rs
@@ -1,7 +1,7 @@
 //! Functions to generate random sequences
 use rand::Rng;
 use rv::dist::Gaussian;
-use rv::traits::Rv;
+use rv::traits::Sampleable;
 
 /// Generate a series of draws from two Gaussian process that switches
 /// at `switch` into the sequence.

--- a/changepoint/src/utils.rs
+++ b/changepoint/src/utils.rs
@@ -2,7 +2,8 @@
 
 use rand::Rng;
 use rv::{
-    misc::argmax, prelude::Categorical, prelude::CategoricalError, prelude::Rv,
+    misc::argmax, prelude::Categorical, prelude::CategoricalError,
+    prelude::Sampleable,
 };
 use std::fmt::Display;
 use std::fs::File;


### PR DESCRIPTION
This required a few small changes related to the split of the `Rv`
trait into `Sampleable` and `HasDensity`, but nothing major.

The `ln_gamma` changes were due to some warnings given by rustc
stating that there may be an inherent `ln_gamma` method added to
f64 eventually; using the explicit `special::Gamma` method avoids
these warnings.
